### PR TITLE
Add iam_profile to script args

### DIFF
--- a/migration/bring-your-own-role/README.md
+++ b/migration/bring-your-own-role/README.md
@@ -136,7 +136,8 @@ python3 byor.py use-your-own-role \
     --domain-id <SageMaker-Unified-Studio-Domain-Id> \
     --project-id <SageMaker-Unified-Studio-Project-Id> \
     --bring-in-role-arn <Custom-IAM-Role-Arn> \
-    --region <region-code>
+    --region <region-code> \
+    --iam-profile <aws-credentials-profile-name>
 ```
 #### Use Case 2: Enhance SageMaker Unified Studio Project Role using your own Role
 ```
@@ -144,9 +145,11 @@ python3 byor.py enhance-project-role \
     --domain-id <SageMaker-Unified-Studio-Domain-Id> \
     --project-id <SageMaker-Unified-Studio-Project-Id> \
     --bring-in-role-arn <Custom-IAM-Role-Arn> \
-    --region <region-code>
+    --region <region-code> \
+    --iam-profile <aws-credentials-profile-name>
 ```
 ### Important Notes
 - Both commands will display a preview of proposed changes by default. To apply the changes for `use-your-own-role`, add the `--execute` `--force-update` flag. To apply the changes for `enhance-project-role`, add the `--execute` flag
 - The `--region` parameter is optional and only required when necessary. If not specified, it defaults to AWS region specified in the CLI credentials config
+- The `--iam-profile` parameter is optional. When provided, uses credentials from the specified AWS profile. Otherwise, falls back to default AWS credential resolution (environment variables, default profile, or instance role).
 - In `use-your-own-role` case, the role you bring in must not be used as the project User Role in another SageMaker Unified Studio Project

--- a/migration/bring-your-own-role/byor.py
+++ b/migration/bring-your-own-role/byor.py
@@ -653,6 +653,10 @@ def _add_common_arguments(parser):
     parser.add_argument('--endpoint',
                         help='Endpoint where you have your Project',
                         required=False)
+    parser.add_argument("--iam-profile", type=str,
+                        required=False,
+                        help="AWS Credentials profile to use."
+                        )
 
 def _parse_args():
     parser = argparse.ArgumentParser(description='Tool which grant your role ability to work for specified Project.')
@@ -675,8 +679,12 @@ def _parse_args():
 def byor_main():
     args = _parse_args()
     session = boto3.Session()
-    if (args.region):
+    if args.region and args.iam_profile:
+        session = boto3.Session(profile_name=args.iam_profile, region_name=args.region)
+    elif args.region:
         session = boto3.Session(region_name=args.region)
+    elif args.iam_profile:
+        session = boto3.Session(profile_name=args.iam_profile)
     iam_client = session.client('iam')
     datazone = session.client('datazone')
     lakeformation = session.client('lakeformation')


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Added an optional parameter iam_profile that can be passed to the BYOR script for any users who want to use credentials from specific aws credentials profile.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
