### PR TITLE
Bug fixes and add blueprint policy grant

### DIFF
--- a/terraform/constructs/create-blueprint-policy-grant/main.tf
+++ b/terraform/constructs/create-blueprint-policy-grant/main.tf
@@ -1,0 +1,27 @@
+/*
+ * Enables all blueprints for SMUS domain
+ */
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+resource "awscc_datazone_policy_grant" "blueprint_policy_grants" {
+  for_each = var.blueprint_ids
+  domain_identifier = var.domain_id
+  entity_type = "ENVIRONMENT_BLUEPRINT_CONFIGURATION"
+  entity_identifier = "${data.aws_caller_identity.current.account_id}:${each.value}"
+  policy_type  = "CREATE_ENVIRONMENT_FROM_BLUEPRINT"
+  detail = {
+     create_environment_from_blueprint = jsonencode({})
+   }
+  principal = {
+    project = {
+      project_designation = "CONTRIBUTOR"
+      project_grant_filter = {
+        domain_unit_filter = {
+          domain_unit  = var.domain_unit_id
+          include_child_domain_units  = true
+         }
+       }
+     }
+   }
+}

--- a/terraform/constructs/create-blueprint-policy-grant/variables.tf
+++ b/terraform/constructs/create-blueprint-policy-grant/variables.tf
@@ -1,0 +1,14 @@
+variable domain_id {
+  description = "Domain for which blueprint needs to be enabled"
+  type = string
+}
+
+variable domain_unit_id {
+  description = "Domain unit for which blueprint needs to be enabled"
+  type = string
+}
+
+variable blueprint_ids {
+  description = "A list of blueprint IDs to be enabled"
+  type = map(string)
+}

--- a/terraform/constructs/create-service-roles/main.tf
+++ b/terraform/constructs/create-service-roles/main.tf
@@ -53,10 +53,16 @@ resource "aws_iam_role" "sagemaker_domain_execution_role" {
 resource "aws_iam_role_policy_attachment" "domain-execution-attach-studio-execution-policy" {
   role       = aws_iam_role.sagemaker_domain_execution_role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/SageMakerStudioDomainExecutionRolePolicy"
+  depends_on = [ 
+    aws_iam_role.sagemaker_domain_execution_role
+  ]
 }
 resource "aws_iam_role_policy_attachment" "domain-execution-attach-datazone-execution-policy" {
   role       = aws_iam_role.sagemaker_domain_execution_role.name
   policy_arn =  "arn:aws:iam::aws:policy/service-role/AmazonDataZoneDomainExecutionRolePolicy"
+  depends_on = [ 
+    aws_iam_role_policy_attachment.domain-execution-attach-studio-execution-policy
+  ]
 }
 
 resource "aws_iam_role" "sagemaker_service_role" {
@@ -79,9 +85,15 @@ resource "aws_iam_role" "sagemaker_service_role" {
     Version = "2012-10-17"
   })
   path = "/service-role/"
+  depends_on = [ 
+    aws_iam_role_policy_attachment.domain-execution-attach-datazone-execution-policy
+  ]
 }
 
 resource "aws_iam_role_policy_attachment" "service-attach-service-policy" {
   role       = aws_iam_role.sagemaker_service_role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/SageMakerStudioDomainServiceRolePolicy"
+  depends_on = [ 
+    aws_iam_role.sagemaker_service_role
+  ]
 }

--- a/terraform/constructs/create-service-roles/outputs.tf
+++ b/terraform/constructs/create-service-roles/outputs.tf
@@ -1,6 +1,7 @@
 output "sagemaker_domain_execution_role_arn" {
   value = aws_iam_role.sagemaker_domain_execution_role.arn
   depends_on = [ 
+    aws_iam_role.sagemaker_domain_execution_role,
     aws_iam_role_policy_attachment.domain-execution-attach-datazone-execution-policy,
     aws_iam_role_policy_attachment.domain-execution-attach-studio-execution-policy 
   ]
@@ -8,6 +9,7 @@ output "sagemaker_domain_execution_role_arn" {
 output "sagemaker_service_role_arn" {
   value = aws_iam_role.sagemaker_service_role.arn
   depends_on = [ 
+    aws_iam_role.sagemaker_service_role,
     aws_iam_role_policy_attachment.service-attach-service-policy
   ]
 }
@@ -15,6 +17,7 @@ output "sagemaker_service_role_arn" {
 output "sagemaker_domain_execution_role_id" {
   value = aws_iam_role.sagemaker_domain_execution_role.id
   depends_on = [ 
+    aws_iam_role.sagemaker_domain_execution_role,
     aws_iam_role_policy_attachment.domain-execution-attach-datazone-execution-policy,
     aws_iam_role_policy_attachment.domain-execution-attach-studio-execution-policy 
   ]
@@ -22,6 +25,7 @@ output "sagemaker_domain_execution_role_id" {
 output "sagemaker_service_role_id" {
   value = aws_iam_role.sagemaker_service_role.id
   depends_on = [ 
+    aws_iam_role.sagemaker_service_role,
     aws_iam_role_policy_attachment.service-attach-service-policy
   ]
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -106,6 +106,37 @@ module "blueprints" {
   ]
 }
 
+module "blueprint_policy_grants" {
+  source         = "./constructs/create-blueprint-policy-grant"
+  domain_id      = awscc_datazone_domain.domain.domain_id
+  domain_unit_id = awscc_datazone_domain.domain.root_domain_unit_id
+
+  blueprint_ids = tomap({
+    lakehouse_catalog_id=module.blueprints.lakehouse_catalog_id,
+    amazon_bedrock_guardrail_id=module.blueprints.amazon_bedrock_guardrail_id,
+    ml_experiments_id=module.blueprints.ml_experiments_id,
+    tooling_id=module.blueprints.tooling_id,
+    redshift_serverless_id=module.blueprints.redshift_serverless_id,
+    emr_serverless_id=module.blueprints.emr_serverless_id,
+    workflows_id=module.blueprints.workflows_id,
+    amazon_bedrock_prompt_id=module.blueprints.amazon_bedrock_prompt_id,
+    data_lake_id=module.blueprints.data_lake_id,
+    amazon_bedrock_evaluation_id=module.blueprints.amazon_bedrock_evaluation_id,
+    amazon_bedrock_knowledge_base_id=module.blueprints.amazon_bedrock_knowledge_base_id,
+    partner_apps_id=module.blueprints.partner_apps_id,
+    amazon_bedrock_chat_agent_id=module.blueprints.amazon_bedrock_chat_agent_id,
+    amazon_bedrock_function_id=module.blueprints.amazon_bedrock_function_id,
+    amazon_bedrock_flow_id=module.blueprints.amazon_bedrock_flow_id,
+    emr_on_ec2_id=module.blueprints.emr_on_ec2_id,
+    quick_sight_id=module.blueprints.quick_sight_id,
+  })
+  // deploy in associated account
+  providers = {
+    "aws"   = aws.alternate
+    "awscc" = awscc.alternate
+  }
+}
+
 // project profiles are created in primary account and reference the account where blueprints are located
 // in a multi-account configuration, the project profiles are created in the primary account and reference blueprints created in the associated account
 /*

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -6,40 +6,46 @@ data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 
 data "aws_region" "alternate" {
-    provider = aws.alternate
+  provider = aws.alternate
 }
 data "aws_caller_identity" "alternate" {
-    provider = aws.alternate
+  provider = aws.alternate
 }
 
 // deploy in primary account
 module "domain_service_roles" {
-    source = "./constructs/create-service-roles"
-    
+  source = "./constructs/create-service-roles"
+
+}
+
+// avoid race condition by forcing domain to be created in series
+resource "time_sleep" "wait_after_role_creation" {
+  depends_on = [module.domain_service_roles]
+  create_duration = "10s"
 }
 
 // create domain in primary account
 resource "awscc_datazone_domain" "domain" {
-  provider = awscc
-  name = var.domain_name
-  description = "Test Domain"
+  provider              = awscc
+  name                  = var.domain_name
+  description           = "Test Domain"
   domain_execution_role = module.domain_service_roles.sagemaker_domain_execution_role_arn
-  service_role = module.domain_service_roles.sagemaker_service_role_arn
-  domain_version = "V2"
+  service_role          = module.domain_service_roles.sagemaker_service_role_arn
+  domain_version        = "V2"
   single_sign_on = {
-    type = "IAM_IDC"
+    type            = "IAM_IDC"
     user_assignment = "AUTOMATIC"
   }
   depends_on = [
-    module.domain_service_roles
+    time_sleep.wait_after_role_creation
   ]
 }
 
 // create RAM share from primary account
 resource "awscc_ram_resource_share" "domain_share" {
-  provider = awscc
-  name = "DataZone-${awscc_datazone_domain.domain.name}-${awscc_datazone_domain.domain.domain_id}"
-  resource_arns = [awscc_datazone_domain.domain.arn]
+  provider                  = awscc
+  name                      = "DataZone-${awscc_datazone_domain.domain.name}-${awscc_datazone_domain.domain.domain_id}"
+  resource_arns             = [awscc_datazone_domain.domain.arn]
   allow_external_principals = true
   permission_arns = [
     "arn:aws:ram::aws:permission/AWSRAMPermissionsAmazonDatazoneDomainExtendedServiceAccess"
@@ -52,52 +58,52 @@ resource "awscc_ram_resource_share" "domain_share" {
 // accept RAM share from associated account
 // this step can be skipped when using AWS Organizations, as resources will be automatically accepted
 resource "aws_ram_resource_share_accepter" "receiver_accept" {
-  provider = aws.alternate
+  provider  = aws.alternate
   share_arn = awscc_ram_resource_share.domain_share.arn
 }
 
 // create storage bucket in associated account
 resource "aws_s3_bucket" "dzs3_bucket" {
   provider = aws.alternate
-  bucket = "amazon-sagemaker-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.region}-${replace(awscc_datazone_domain.domain.domain_id, "dzd_", "")}"
+  bucket   = "amazon-sagemaker-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.region}-${replace(awscc_datazone_domain.domain.domain_id, "dzd_", "")}"
 }
 
 // create roles in associated account
 // when doing cross-account deployment, the account id will be set to the source account to allow for the domain to call in
 module "blueprint_roles" {
-    source = "./constructs/create-blueprint-roles"
-    domain_arn = awscc_datazone_domain.domain.arn
-    domain_id = awscc_datazone_domain.domain.domain_id
-    account_id = data.aws_caller_identity.current.account_id
-    // deploy in associated account
-    providers = {
-      "aws" = aws.alternate
-      "awscc" = awscc.alternate
-    }
-    depends_on = [
-      aws_ram_resource_share_accepter.receiver_accept
-    ]
+  source     = "./constructs/create-blueprint-roles"
+  domain_arn = awscc_datazone_domain.domain.arn
+  domain_id  = awscc_datazone_domain.domain.domain_id
+  account_id = data.aws_caller_identity.current.account_id
+  // deploy in associated account
+  providers = {
+    "aws"   = aws.alternate
+    "awscc" = awscc.alternate
+  }
+  depends_on = [
+    aws_ram_resource_share_accepter.receiver_accept
+  ]
 }
 
 // enable blueprints for the domain
 // If a cross-account association is used, these blueprints will be created in the associated account by specifying the provider
 module "blueprints" {
-    source = "./constructs/create-blueprint"
-    domain_id = awscc_datazone_domain.domain.domain_id
-    amazon_sage_maker_manage_access_role = module.blueprint_roles.sagemaker_manage_access_role_arn
-    amazon_sage_maker_provisioning_role = module.blueprint_roles.sagemaker_provisioning_role_arn
-    dzs3_bucket = "s3://${aws_s3_bucket.dzs3_bucket.id}/"
-    sage_maker_subnets = join(",",var.sagemaker_subnets)
-    amazon_sage_maker_vpc_id = var.sagemaker_vpc_id
-    // deploy in associated account
-    providers = {
-      "aws" = aws.alternate
-      "awscc" = awscc.alternate
-    }
-    // need to accept and associate domain before enabling blueprints
-    depends_on = [
-      aws_ram_resource_share_accepter.receiver_accept
-    ]
+  source                               = "./constructs/create-blueprint"
+  domain_id                            = awscc_datazone_domain.domain.domain_id
+  amazon_sage_maker_manage_access_role = module.blueprint_roles.sagemaker_manage_access_role_arn
+  amazon_sage_maker_provisioning_role  = module.blueprint_roles.sagemaker_provisioning_role_arn
+  dzs3_bucket                          = "s3://${aws_s3_bucket.dzs3_bucket.id}/"
+  sage_maker_subnets                   = join(",", var.sagemaker_subnets)
+  amazon_sage_maker_vpc_id             = var.sagemaker_vpc_id
+  // deploy in associated account
+  providers = {
+    "aws"   = aws.alternate
+    "awscc" = awscc.alternate
+  }
+  // need to accept and associate domain before enabling blueprints
+  depends_on = [
+    aws_ram_resource_share_accepter.receiver_accept
+  ]
 }
 
 // project profiles are created in primary account and reference the account where blueprints are located


### PR DESCRIPTION
*Description of changes:*
- Added time sleep to avoid IAM service role and domain creation race condition

Fixes error:
```
│ Error: AWS SDK Go Service Operation Incomplete
│ 
│   with awscc_datazone_domain.domain,
│   on main.tf line 22, in resource "awscc_datazone_domain" "domain":
│   22: resource "awscc_datazone_domain" "domain" {
│ 
│ Waiting for Cloud Control API service CreateResource operation completion returned: waiter state transitioned to FAILED. StatusMessage:
│ Unable to assume role 
```

- Add `create-blueprint-policy-grant` module to support creation of [awscc_datazone_policy_grant](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/datazone_policy_grant) for blueprints.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
