### PR TITLE
Fix profile name field mismatch between YAML and Python

### DIFF
--- a/experimental/SMUS-CICD-pipeline-cli/docs/manifest.md
+++ b/experimental/SMUS-CICD-pipeline-cli/docs/manifest.md
@@ -190,7 +190,7 @@ stages:
     project:
       name: test-marketing
       create: true
-      profile_name: 'All capabilities'
+      profileName: 'All capabilities'
       owners: ['alice@company.com']
       contributors: ['bob@company.com']
       role:
@@ -261,7 +261,7 @@ stages:
     project:
       name: prod-marketing
       create: true
-      profile_name: 'All capabilities'
+      profileName: 'All capabilities'
       owners: ['alice@company.com']
       contributors: []
     
@@ -451,7 +451,7 @@ stages:
     project:
       name: test-marketing
       create: true
-      profile_name: 'All capabilities'
+      profileName: 'All capabilities'
       owners: ['alice@company.com']
       contributors: ['bob@company.com', 'charlie@company.com']
       user_parameters:

--- a/experimental/SMUS-CICD-pipeline-cli/examples/demo-manifest.yaml
+++ b/experimental/SMUS-CICD-pipeline-cli/examples/demo-manifest.yaml
@@ -15,7 +15,7 @@ stages:
     project:
       name: test-project-name
       create: true
-      profile_name: All capabilities
+      profileName: All capabilities
       owners:
       - arn:aws:iam::123456789012:role/GitHubActionsRole-SMUS-CLI-Tests
       contributors: []
@@ -26,7 +26,7 @@ stages:
     project:
       name: prod-project-name
       create: true
-      profile_name: All capabilities
+      profileName: All capabilities
       owners:
       - arn:aws:iam::123456789012:role/GitHubActionsRole-SMUS-CLI-Tests
       contributors: []

--- a/experimental/SMUS-CICD-pipeline-cli/examples/manifest-with-role-policies.yaml
+++ b/experimental/SMUS-CICD-pipeline-cli/examples/manifest-with-role-policies.yaml
@@ -11,7 +11,7 @@ stages:
     
     project:
       name: dev-project
-      profile_name: DataAnalyticsProfile
+      profileName: DataAnalyticsProfile
       
       # Option 1: Create new role with policies
       role:
@@ -28,7 +28,7 @@ stages:
     
     project:
       name: prod-project
-      profile_name: DataAnalyticsProfile
+      profileName: DataAnalyticsProfile
       
       # Option 2: Use existing role and attach additional policies
       role:

--- a/experimental/SMUS-CICD-pipeline-cli/examples/mwaa-example/DemoMarketingPipeline-MWAA.yaml
+++ b/experimental/SMUS-CICD-pipeline-cli/examples/mwaa-example/DemoMarketingPipeline-MWAA.yaml
@@ -62,7 +62,7 @@ stages:
     initialization:
       project:
         create: true
-        profile_name: All capabilities
+        profileName: All capabilities
         owners:
         - arn:aws:iam::123456789012:role/GitHubActionsRole-SMUS-CLI-Tests
         - Eng1
@@ -88,7 +88,7 @@ stages:
     initialization:
       project:
         create: true
-        profile_name: All capabilities
+        profileName: All capabilities
         owners:
         - arn:aws:iam::123456789012:role/GitHubActionsRole-SMUS-CLI-Tests
         - Eng1

--- a/experimental/SMUS-CICD-pipeline-cli/examples/serverless-example/DemoMarketingPipeline-Serverless.yaml
+++ b/experimental/SMUS-CICD-pipeline-cli/examples/serverless-example/DemoMarketingPipeline-Serverless.yaml
@@ -51,7 +51,7 @@ stages:
     initialization:
       project:
         create: true
-        profile_name: All capabilities
+        profileName: All capabilities
         owners:
         - arn:aws:iam::123456789012:role/GitHubActionsRole-SMUS-CLI-Tests
         - Eng1
@@ -84,7 +84,7 @@ stages:
     initialization:
       project:
         create: true
-        profile_name: All capabilities
+        profileName: All capabilities
         owners:
         - arn:aws:iam::123456789012:role/GitHubActionsRole-SMUS-CLI-Tests
         - Eng1

--- a/experimental/SMUS-CICD-pipeline-cli/src/smus_cicd/application/application-manifest-schema.yaml
+++ b/experimental/SMUS-CICD-pipeline-cli/src/smus_cicd/application/application-manifest-schema.yaml
@@ -399,7 +399,7 @@ definitions:
             type: boolean
             description: "Whether the CLI should manage this stage (create/update infrastructure)"
             default: false
-          profile_name:
+          profileName:
             type: string
             description: "Project profile name"
             examples: 

--- a/experimental/SMUS-CICD-pipeline-cli/src/smus_cicd/application/manifest-schema.yaml
+++ b/experimental/SMUS-CICD-pipeline-cli/src/smus_cicd/application/manifest-schema.yaml
@@ -240,7 +240,7 @@ definitions:
             type: boolean
             description: "Whether the CLI should manage this target (create/update infrastructure)"
             default: false
-          profile_name:
+          profileName:
             type: string
             description: "Project profile name"
             examples: 

--- a/experimental/SMUS-CICD-pipeline-cli/tests/integration/create_test_app/manifest.yaml
+++ b/experimental/SMUS-CICD-pipeline-cli/tests/integration/create_test_app/manifest.yaml
@@ -37,7 +37,7 @@ stages:
     project:
       name: create-test-project
       create: true
-      profile_name: All capabilities
+      profileName: All capabilities
       owners:
       - Eng1
       - arn:aws:iam::${AWS_ACCOUNT_ID}:role/GitHubActionsRole-SMUS-CLI-Tests

--- a/experimental/SMUS-CICD-pipeline-cli/tests/integration/delete_test_app/manifest.yaml
+++ b/experimental/SMUS-CICD-pipeline-cli/tests/integration/delete_test_app/manifest.yaml
@@ -37,7 +37,7 @@ stages:
     project:
       name: delete-test-project
       create: true
-      profile_name: All capabilities
+      profileName: All capabilities
       owners:
       - Eng1
       - arn:aws:iam::${AWS_ACCOUNT_ID}:role/Admin

--- a/experimental/SMUS-CICD-pipeline-cli/tests/integration/glue-mwaa-catalog-app/manifest.yaml
+++ b/experimental/SMUS-CICD-pipeline-cli/tests/integration/glue-mwaa-catalog-app/manifest.yaml
@@ -59,7 +59,7 @@ stages:
     project:
       name: test-glue-mwaa-catalog-app
       create: true
-      profile_name: All capabilities
+      profileName: All capabilities
       owners:
       - Eng1
       - arn:aws:iam::${AWS_ACCOUNT_ID}:role/GitHubActionsRole-SMUS-CLI-Tests
@@ -91,7 +91,7 @@ stages:
     project:
       name: prod-glue-mwaa-catalog-app
       create: true
-      profile_name: All capabilities
+      profileName: All capabilities
       owners:
       - Eng1
       - arn:aws:iam::${AWS_ACCOUNT_ID}:role/GitHubActionsRole-SMUS-CLI-Tests

--- a/experimental/SMUS-CICD-pipeline-cli/tests/integration/multi_target_app_airless/manifest.yaml
+++ b/experimental/SMUS-CICD-pipeline-cli/tests/integration/multi_target_app_airless/manifest.yaml
@@ -47,7 +47,7 @@ stages:
     project:
       name: integration-airless-test
       create: true
-      profile_name: All capabilities
+      profileName: All capabilities
       owners:
       - Eng1
       - arn:aws:iam::${AWS_ACCOUNT_ID}:role/GitHubActionsRole-SMUS-CLI-Tests
@@ -77,7 +77,7 @@ stages:
     project:
       name: integration-airless-test
       create: true
-      profile_name: All capabilities
+      profileName: All capabilities
       owners:
       - Eng1
       - arn:aws:iam::${AWS_ACCOUNT_ID}:role/GitHubActionsRole-SMUS-CLI-Tests


### PR DESCRIPTION
Problem

The code was reading profileName from YAML manifests, but the schemas and all manifest files used profile_name. This caused the profile value to never be read, breaking profile selection.

Solution

 - Updated schemas and manifests to use profileName (camelCase) to match the YAML field convention
 - Python code keeps using profile_name (snake_case) internally per Python naming conventions
 - Code now correctly reads profileName from YAML and maps it to the profile_name dataclass field

Profile selection now works as intended.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
