### PR TITLE
Update README: point CICD pipeline reference to new standalone repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ This repository contains utilities for Amazon SageMaker Unified Studio. It is st
     - [Bring your own Glue Data Catalog assets](https://github.com/aws/Unified-Studio-for-Amazon-Sagemaker/tree/main/migration/bring-your-own-gdc-assets) in SageMaker Unified Studio project.
     - [Bring your own S3 tables](https://github.com/aws/Unified-Studio-for-Amazon-Sagemaker/tree/main/migration/bring-your-own-s3-tables) in SageMaker Unified Studio project.
     - Migrate [Amazon SageMaker AI](https://github.com/aws/Unified-Studio-for-Amazon-Sagemaker/tree/main/migration/sagemaker-ai) resources to SageMaker Unified Studio project. 
-- Experimental CICD Pipeline support. This library supports creation of CICD pipeline using SageMaker Unified Studio that allows bundling and deploying code to different stages of development. 
-    - [experimental/SMUS-CICD-pipeline-cli](https://github.com/aws/Unified-Studio-for-Amazon-Sagemaker/tree/main/experimental/SMUS-CICD-pipeline-cli)
+- SMUS CICD Pipeline support. This library supports creation of CICD pipeline using SageMaker Unified Studio that allows bundling and deploying code to different stages of development. 
+    - [CICD-for-SageMakerUnifiedStudio](https://github.com/aws/CICD-for-SageMakerUnifiedStudio)
 
 
 To read more about Amazon SageMaker Unified Studio, please refer to:


### PR DESCRIPTION
Updates the README to reference the new standalone [CICD-for-SageMakerUnifiedStudio](https://github.com/aws/CICD-for-SageMakerUnifiedStudio) repository instead of the experimental path.